### PR TITLE
Fix error code unmarshaling

### DIFF
--- a/schema/enrollment.go
+++ b/schema/enrollment.go
@@ -2,7 +2,7 @@ package schema
 
 // EnrollmentResponse is response mapping from Enrollment request
 type EnrollmentResponse struct {
-	ErrorCode          int    `json:"errorCode,omitempty"`
+	ErrorCode          int    `json:"errorCode,string,omitempty"`
 	ErrorMessage       string `json:"errorMessage,omitempty"`
 	Enrolled           byte   `json:"enrollment,omitempty"`
 	EmitterName        string `json:"emitterName,omitempty"`

--- a/schema/order.go
+++ b/schema/order.go
@@ -2,7 +2,7 @@ package schema
 
 // Response is mapped response received from Sberbank API
 type Response struct {
-	ErrorCode    int    `json:"errorCode,omitempty"`
+	ErrorCode    int    `json:"errorCode,string,omitempty"`
 	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
@@ -10,7 +10,7 @@ type Response struct {
 type OrderResponse struct {
 	OrderId      string `json:"orderId,omitempty"`
 	FormUrl      string `json:"formUrl,omitempty"`
-	ErrorCode    int    `json:"errorCode,omitempty"`
+	ErrorCode    int    `json:"errorCode,string,omitempty"`
 	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
@@ -20,7 +20,7 @@ type OrderStatusResponse struct {
 	OrderStatus           int    `json:"orderStatus,omitempty"`
 	ActionCode            int    `json:"actionCode"`
 	ActionCodeDescription string `json:"actionCodeDescription"`
-	ErrorCode             int    `json:"errorCode,omitempty"`
+	ErrorCode             int    `json:"errorCode,string,omitempty"`
 	ErrorMessage          string `json:"errorMessage,omitempty"`
 	Amount                int    `json:"amount"`
 	Currency              int    `json:"currency,omitempty"`

--- a/schema/receipt.go
+++ b/schema/receipt.go
@@ -2,7 +2,7 @@ package schema
 
 // ReceiptStatus is response received from GetReceiptStatus
 type ReceiptStatus struct {
-	ErrorCode    int    `json:"errorCode,omitempty"`
+	ErrorCode    int    `json:"errorCode,string,omitempty"`
 	ErrorMessage string `json:"errorMessage,omitempty"`
 	OrderNumber  string `json:"orderNumber,omitempty"`
 	OrderId      string `json:"orderId,omitempty"`


### PR DESCRIPTION
Sberbank returns "intstring" (for example, "0") and this cannot be parsed without special tag `json:",string"` on int field in response structs.

I added it, please accept the pull request.