### PR TITLE
make Bind fields public to bind/unbind cards outside of module

### DIFF
--- a/bind/client.go
+++ b/bind/client.go
@@ -18,15 +18,15 @@ type Client struct {
 
 // Binding is used to make binding related requests
 type Binding struct {
-	bindingID  string
-	newExpiry  string
+	BindingID  string
+	NewExpiry  string
 	JSONParams map[string]string
 }
 
 func (binding Binding) Validate() error {
 	return validation.ValidateStruct(&binding,
-		validation.Field(&binding.bindingID, validation.Required),
-		validation.Field(&binding.newExpiry, validation.Match(regexp.MustCompile("^[0-9]{6}$"))),
+		validation.Field(&binding.BindingID, validation.Required),
+		validation.Field(&binding.NewExpiry, validation.Match(regexp.MustCompile("^[0-9]{6}$"))),
 	)
 }
 
@@ -64,7 +64,7 @@ var bind = func(ctx context.Context, client Client, path string, binding Binding
 	}
 
 	body := make(map[string]string)
-	body["bindingId"] = binding.bindingID
+	body["bindingId"] = binding.BindingID
 
 	return client.bind(ctx, path, body, binding.JSONParams)
 }
@@ -85,8 +85,8 @@ func (c Client) ExtendBinding(ctx context.Context, binding Binding) (*schema.Res
 	}
 
 	body := make(map[string]string)
-	body["bindingId"] = binding.bindingID
-	body["newExpiry"] = binding.newExpiry
+	body["bindingId"] = binding.BindingID
+	body["newExpiry"] = binding.NewExpiry
 
 	return c.bind(ctx, path, body, binding.JSONParams)
 }

--- a/bind/client_test.go
+++ b/bind/client_test.go
@@ -42,12 +42,12 @@ func TestClient_BindCard(t *testing.T) {
 	RegisterTestingT(t)
 	t.Run("Test Bind Validate", func(t *testing.T) {
 		binding := Binding{
-			bindingID: "",
+			BindingID: "",
 		}
 
 		_, _, err := BindCard(context.Background(), binding)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("bindingID: cannot be blank"))
+		Expect(err.Error()).To(ContainSubstring("BindingID: cannot be blank"))
 	})
 
 	t.Run("Test Binding response mapping", func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestClient_BindCard(t *testing.T) {
 		})
 
 		binding := Binding{
-			bindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
+			BindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
 		}
 
 		response, _, err := BindCard(context.Background(), binding)
@@ -77,32 +77,32 @@ func TestClient_BindCard(t *testing.T) {
 
 	t.Run("Test UnBind Validate", func(t *testing.T) {
 		binding := Binding{
-			bindingID: "",
+			BindingID: "",
 		}
 
 		_, _, err := UnBindCard(context.Background(), binding)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("bindingID: cannot be blank"))
+		Expect(err.Error()).To(ContainSubstring("BindingID: cannot be blank"))
 	})
 
 	t.Run("Test validate ExtendBinding with empty value", func(t *testing.T) {
 		binding := Binding{
-			bindingID: "",
+			BindingID: "",
 		}
 
 		_, _, err := ExtendBinding(context.Background(), binding)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("bindingID: cannot be blank"))
+		Expect(err.Error()).To(ContainSubstring("BindingID: cannot be blank"))
 	})
 
 	t.Run("Test validate ExtendBinding Expiry", func(t *testing.T) {
 		binding := Binding{
-			bindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
-			newExpiry: "123",
+			BindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
+			NewExpiry: "123",
 		}
 		_, _, err := ExtendBinding(context.Background(), binding)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("newExpiry: must be in a valid format."))
+		Expect(err.Error()).To(ContainSubstring("NewExpiry: must be in a valid format."))
 	})
 
 	t.Run("Test ExtendBinding is ok", func(t *testing.T) {
@@ -119,8 +119,8 @@ func TestClient_BindCard(t *testing.T) {
 		})
 
 		binding := Binding{
-			bindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
-			newExpiry: "123123",
+			BindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
+			NewExpiry: "123123",
 		}
 		_, _, err := ExtendBinding(context.Background(), binding)
 		// We don't care what underlying error happened
@@ -150,7 +150,7 @@ func TestClient_BindCard(t *testing.T) {
 		})
 
 		binding := Binding{
-			bindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
+			BindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
 		}
 
 		response, _, err := BindCard(context.Background(), binding)
@@ -167,11 +167,11 @@ func TestClient_ValidateBind(t *testing.T) {
 	RegisterTestingT(t)
 	t.Run("Test bind validator", func(t *testing.T) {
 		binding := Binding{
-			bindingID: "",
+			BindingID: "",
 		}
 		err := binding.Validate()
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("bindingID: cannot be blank"))
+		Expect(err.Error()).To(ContainSubstring("BindingID: cannot be blank"))
 	})
 }
 
@@ -179,8 +179,8 @@ func TestClient_ValidateExpiry(t *testing.T) {
 	RegisterTestingT(t)
 	t.Run("Test expiry is ok", func(t *testing.T) {
 		binding := Binding{
-			bindingID: "123",
-			newExpiry: "123123",
+			BindingID: "123",
+			NewExpiry: "123123",
 		}
 		err := binding.Validate()
 		Expect(err).ToNot(HaveOccurred())
@@ -196,8 +196,8 @@ func TestClient_Bind(t *testing.T) {
 		prepareClient(testServer.URL)
 
 		binding := Binding{
-			bindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
-			newExpiry: "123123",
+			BindingID: "fd3afc57-c6d0-4e08-aaef-1b7cfeb093dc",
+			NewExpiry: "123123",
 		}
 		testServer.Mux.HandleFunc(endpoints.Register, func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Bad Request", http.StatusBadRequest)


### PR DESCRIPTION
Currently we cannot unbind a card. Binding ID must be exported to call this method.