### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -1,5 +1,8 @@
 name: "StaticCheck"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/helios-ag/sberbank-acquiring-go/security/code-scanning/1](https://github.com/helios-ag/sberbank-acquiring-go/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily performs read-only operations (e.g., fetching code and running tests), the `contents: read` permission is sufficient. This permission allows the workflow to read repository contents without granting write access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`ci`) to limit permissions for that job only. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
